### PR TITLE
CASE-518 iOS multipart form bugfix

### DIFF
--- a/lib/serverpipe.js
+++ b/lib/serverpipe.js
@@ -58,11 +58,25 @@ export function postMultipartFormWithCredentials(url, form, options = {}) {
     Accept: 'application/json',
   };
   const headers = 'headers' in options ? [...options.headers, defaultHeaders] : defaultHeaders;
-
   headers[getCsrfHeaderName()] = getCsrfToken();
+
+  const fileInputs = form.querySelectorAll('input[type="file"]:not([disabled])')
+  fileInputs.forEach(function(fi) {
+    if (fi.files.length > 0) {
+      return;
+    }
+    fi.setAttribute('disabled', '');
+  });
+
+  const formData = new FormData(form);
+  
+  fileInputs.forEach(function(fi) {
+    fi.removeAttribute('disabled');
+  });
+
   return fetchWithCredentials(url, {
     method: 'POST',
-    body: new FormData(form),
+    body: formData,
     headers,
     ...options,
   });

--- a/lib/serverpipe.js
+++ b/lib/serverpipe.js
@@ -60,6 +60,7 @@ export function postMultipartFormWithCredentials(url, form, options = {}) {
   const headers = 'headers' in options ? [...options.headers, defaultHeaders] : defaultHeaders;
   headers[getCsrfHeaderName()] = getCsrfToken();
 
+  // CASE-518 disable empty file inputs for iOS 11
   const fileInputs = form.querySelectorAll('input[type="file"]:not([disabled])')
   fileInputs.forEach(function(fi) {
     if (fi.files.length > 0) {


### PR DESCRIPTION
This is a workaround for a [webkit bug](https://stackoverflow.com/q/49614091/1155871) affecting iOS 11 (I presume it'd be fixed in the version of Mobile Safari shipped with iOS 12). Any empty file fields in a form will block multipart POST submission, leading to a timeout. Affects CASE, and probably anything else using 1.0.1 atm.