### PR TITLE
Switch to cross-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Server Pipe [![Build Status](https://travis-ci.com/UniversityofWarwick/js-serverpipe.svg?branch=master)](https://travis-ci.com/UniversityofWarwick/js-serverpipe)
 
-This is a basic wrapper for `isomorphic-fetch` that we use to make authenticated requests back to the application server. 
+This is a basic wrapper for `cross-fetch` that we use to make authenticated requests back to the application server. This replaces
+`isomorphic-fetch` which is no longer maintained.

--- a/lib/serverpipe.js
+++ b/lib/serverpipe.js
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-import fetch from 'isomorphic-fetch';
+import fetch from 'cross-fetch';
 import log from 'loglevel';
 import Url from 'url';
 import { getCsrfHeaderName, getCsrfToken } from './csrfToken';
@@ -58,11 +58,25 @@ export function postMultipartFormWithCredentials(url, form, options = {}) {
     Accept: 'application/json',
   };
   const headers = 'headers' in options ? [...options.headers, defaultHeaders] : defaultHeaders;
-
   headers[getCsrfHeaderName()] = getCsrfToken();
+
+  const fileInputs = form.querySelectorAll('input[type="file"]:not([disabled])')
+  fileInputs.forEach(function(fi) {
+    if (fi.files.length > 0) {
+      return;
+    }
+    fi.setAttribute('disabled', '');
+  });
+
+  const formData = new FormData(form);
+  
+  fileInputs.forEach(function(fi) {
+    fi.removeAttribute('disabled');
+  });
+
   return fetchWithCredentials(url, {
     method: 'POST',
-    body: new FormData(form),
+    body: formData,
     headers,
     ...options,
   });

--- a/lib/serverpipe.js
+++ b/lib/serverpipe.js
@@ -60,6 +60,7 @@ export function postMultipartFormWithCredentials(url, form, options = {}) {
   const headers = 'headers' in options ? [...options.headers, defaultHeaders] : defaultHeaders;
   headers[getCsrfHeaderName()] = getCsrfToken();
 
+  // CASE-518 disable empty file inputs for iOS 11
   const fileInputs = form.querySelectorAll('input[type="file"]:not([disabled])')
   fileInputs.forEach(function(fi) {
     if (fi.files.length > 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofwarwick/serverpipe",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -867,6 +867,22 @@
       "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg==",
       "dev": true
     },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -896,14 +912,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.96.tgz",
       "integrity": "sha512-ZUXBUyGLeoJxp4Nt6G/GjBRLnyz8IKQGexZ2ndWaoegThgMGFO1tdDYID5gBV32/1S83osjJHyfzvanE/8HY4Q==",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -993,14 +1001,6 @@
       "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
       "dev": true
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1024,20 +1024,6 @@
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
       }
     },
     "js-levenshtein": {
@@ -1188,15 +1174,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
     },
     "node-modules-regexp": {
       "version": "1.0.0",
@@ -1375,11 +1352,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofwarwick/serverpipe",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Authenticated fetch wrapper",
   "main": "index.js",
   "devDependencies": {
@@ -11,7 +11,7 @@
     "mocha": "5.2.0"
   },
   "dependencies": {
-    "isomorphic-fetch": "2.2.1",
+    "cross-fetch": "3.0.4",
     "loglevel": "1.6.1"
   },
   "scripts": {


### PR DESCRIPTION
This change replaces the underlying proxy library, [isomorphic-fetch](https://www.npmjs.com/package/isomorphic-fetch), with [cross-fetch](https://www.npmjs.com/package/cross-fetch). The former is no longer under development, with its maintainer MIA.

I've raised as a minor version rather than a patch level because although the change _should_ be invisible to dependent apps, it is possible that there may be unexpected differences, so ought to be checked in-app rather than blindly upgraded.

In particular any tests for exception handling which are expecting specific messages are likely to fail, as _cross-fetch_ can return different error text, eg. on network issues.