### PR TITLE
Remove polyfills, take I

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Server Pipe [![Build Status](https://travis-ci.com/UniversityofWarwick/js-serverpipe.svg?branch=master)](https://travis-ci.com/UniversityofWarwick/js-serverpipe)
 
-This is a basic wrapper for `cross-fetch` that we use to make authenticated requests back to the application server. This replaces
+This is a basic wrapper for `fetch()` that we use to make authenticated requests back to the application server. This replaces
 `isomorphic-fetch` which is no longer maintained.
 
 ## Browser support
@@ -14,3 +14,5 @@ import 'core-js/modules/web.dom-collections.for-each';
 You will need:
 
 `npm i core-js@3.1.3`
+
+You will also need an appropriate `Promise` and `fetch()` polyfill.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ This is a basic wrapper for `fetch()` that we use to make authenticated requests
 
 ## Browser support
 
-IE11 will require the following polyfill to enable `NodeList.prototype.forEach` to work:
+IE11 will require the following polyfill to enable `NodeList.prototype.forEach`, `Promise` and `fetch` to work:
 
 ```js
 import 'core-js/modules/web.dom-collections.for-each';
+import 'core-js/features/promise';
+import 'whatwg-fetch'
 ```
 
 You will need:
 
-`npm i core-js@3.1.3`
+`npm i --save core-js@3.1.3`
 
-You will also need an appropriate `Promise` and `fetch()` polyfill.
+`npm i --save whatwg-fetch@3.0.0`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Server Pipe [![Build Status](https://travis-ci.com/UniversityofWarwick/js-serverpipe.svg?branch=master)](https://travis-ci.com/UniversityofWarwick/js-serverpipe)
 
-This is a basic wrapper for `fetch()` that we use to make authenticated requests back to the application server. This replaces
-`isomorphic-fetch` which is no longer maintained.
+This is a basic wrapper for `fetch()` that we use to make authenticated requests back to the application server.
 
 ## Browser support
 

--- a/lib/serverpipe.js
+++ b/lib/serverpipe.js
@@ -1,5 +1,4 @@
 /* eslint-env browser */
-import fetch from 'cross-fetch';
 import log from 'loglevel';
 import Url from 'url';
 import { getCsrfHeaderName, getCsrfToken } from './csrfToken';

--- a/package-lock.json
+++ b/package-lock.json
@@ -867,22 +867,6 @@
       "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg==",
       "dev": true
     },
-    "cross-fetch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
-      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
-      "requires": {
-        "node-fetch": "2.6.0",
-        "whatwg-fetch": "3.0.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-        }
-      }
-    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1064,9 +1048,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "loglevel": {
@@ -1437,11 +1421,6 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
       "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
       "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofwarwick/serverpipe",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Authenticated fetch wrapper",
   "main": "index.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "mocha": "5.2.0"
   },
   "dependencies": {
-    "cross-fetch": "3.0.4",
     "loglevel": "1.6.1"
   },
   "scripts": {


### PR DESCRIPTION
>    If cross-fetch includes a polyfill, that'd be an argument for going back to isomorphic-fetch :( It should be the implementing application that has the responsibility for including polyfills to avoid ending up with 4 different Promise implementations in the bundle